### PR TITLE
Update provider name

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ composer require serdud/socialite-google-one-tap
 ### Add configuration to `config/services.php`
 
 ```php
-'google' => [    
-  'client_id' => env('GOOGLE_CLIENT_ID'),  
-  'client_secret' => env('GOOGLE_CLIENT_SECRET'),  
-  'redirect' => env('GOOGLE_REDIRECT_URI') 
+'google' => [
+  'client_id' => env('GOOGLE_CLIENT_ID'),
+  'client_secret' => env('GOOGLE_CLIENT_SECRET'),
+  'redirect' => env('GOOGLE_REDIRECT_URI')
 ],
 ```
 
@@ -24,21 +24,21 @@ composer require serdud/socialite-google-one-tap
 You should now be able to use the provider like you would regularly use Socialite:
 
 ```php
-return Socialite::driver('google')->stateless()->userFromToken($token);
+return Socialite::driver('google-one-tap')->stateless()->userFromToken($token);
 ```
 
-> **Note**  
-> The token is returned in the ```credential``` field
+> **Note**
+> The token is returned in the `credential` field
 
 ### Returned User fields
 
-- ``id``
-- ``nickname``
-- ``name``
-- ``email``
-- ``avatar``
-- ``given_name``
-- ``family_name``
+- `id`
+- `nickname`
+- `name`
+- `email`
+- `avatar`
+- `given_name`
+- `family_name`
 
 ## Credits
 

--- a/src/SocialiteGoogleOneTapServiceProvider.php
+++ b/src/SocialiteGoogleOneTapServiceProvider.php
@@ -19,7 +19,7 @@ class SocialiteGoogleOneTapServiceProvider extends ServiceProvider
         $socialite = $this->app->make(Factory::class);
 
         $socialite->extend(
-            'google',
+            'google-one-tap',
             fn() => $socialite->buildProvider(SocialiteGoogleOneTap::class, config('services.google')),
         );
     }


### PR DESCRIPTION
By overriding the google driver (without fully implementing the default auth patterns/requirements), folks can't use this library on the same app that also uses the normal auth flow. Unless you only care about Google auth for Chrome users, that's a bad thing. I don't understand how to fully implement the patterns/requirements for normal OAuth using Google's client class; so the next best thing is to leave the existing Google Socialite driver alone and require folks to use either `driver('google')` or `driver('google-one-tap')` depending on the flow they need.